### PR TITLE
stratux specific library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ all: dump1090 view1090
 %.o: %.c *.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(EXTRACFLAGS) -c $< -o $@
 
+lib:
+	$(CC) -c -fpic -DBUILD_LIB=1 $(CPPFLAGS) $(CFLAGS) $(EXTRACFLAGS) dump1090.c anet.c interactive.c mode_ac.c mode_s.c net_io.c crc.c demod_2000.c demod_2400.c stats.c cpr.c icao_filter.c track.c util.c convert.c
+	$(CC) -shared -lm  -o ../libdump1090.so $(LIBS) $(LIBS_RTL) $(LDFLAGS) dump1090.o anet.o interactive.o mode_ac.o mode_s.o net_io.o crc.o demod_2000.o demod_2400.o stats.o cpr.o icao_filter.o track.o util.o convert.o 
+	
 dump1090.o: CFLAGS += `pkg-config --cflags librtlsdr`
 
 dump1090: dump1090.o anet.o interactive.o mode_ac.o mode_s.o net_io.o crc.o demod_2000.o demod_2400.o stats.o cpr.o icao_filter.o track.o util.o convert.o $(COMPAT)

--- a/convert.c
+++ b/convert.c
@@ -4,17 +4,17 @@
 //
 // Copyright (c) 2015 Oliver Jowett <oliver@mutability.co.uk>
 //
-// This file is free software: you may copy, redistribute and/or modify it  
+// This file is free software: you may copy, redistribute and/or modify it
 // under the terms of the GNU General Public License as published by the
-// Free Software Foundation, either version 2 of the License, or (at your  
-// option) any later version.  
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version.
 //
-// This file is distributed in the hope that it will be useful, but  
-// WITHOUT ANY WARRANTY; without even the implied warranty of  
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU  
+// This file is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 // General Public License for more details.
 //
-// You should have received a copy of the GNU General Public License  
+// You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "dump1090.h"
@@ -283,16 +283,16 @@ iq_convert_fn init_converter(input_format_t format,
     }
 
     if (!converters_table[i].fn) {
-        fprintf(stderr, "no suitable converter for format=%d power=%d dc=%d\n",
+        FPRINTF(stderr, "no suitable converter for format=%d power=%d dc=%d\n",
                 format, compute_power, filter_dc);
         return NULL;
     }
 
-    fprintf(stderr, "Using sample converter: %s\n", converters_table[i].description);
+    FPRINTF(stderr, "Using sample converter: %s\n", converters_table[i].description);
 
     *out_state = malloc(sizeof(struct converter_state));
     if (! *out_state) {
-        fprintf(stderr, "can't allocate converter state\n");
+        FPRINTF(stderr, "can't allocate converter state\n");
         return NULL;
     }
 

--- a/cprtests.c
+++ b/cprtests.c
@@ -4,17 +4,17 @@
 //
 // Copyright (c) 2014,2015 Oliver Jowett <oliver@mutability.co.uk>
 //
-// This file is free software: you may copy, redistribute and/or modify it  
+// This file is free software: you may copy, redistribute and/or modify it
 // under the terms of the GNU General Public License as published by the
-// Free Software Foundation, either version 2 of the License, or (at your  
-// option) any later version.  
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version.
 //
-// This file is distributed in the hope that it will be useful, but  
-// WITHOUT ANY WARRANTY; without even the implied warranty of  
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU  
+// This file is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 // General Public License for more details.
 //
-// You should have received a copy of the GNU General Public License  
+// You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
@@ -162,7 +162,7 @@ static int testCPRGlobalAirborne() {
             || fabs(rlat - cprGlobalAirborneTests[i].even_rlat) > 1e-6
             || fabs(rlon - cprGlobalAirborneTests[i].even_rlon) > 1e-6) {
             ok = 0;
-            fprintf(stderr,
+            FPRINTF(stderr,
                     "testCPRGlobalAirborne[%u,EVEN]: FAIL: decodeCPRairborne(%d,%d,%d,%d,EVEN) failed:\n"
                     " result %d  (expected %d)\n"
                     " lat %.6f   (expected %.6f)\n"
@@ -174,7 +174,7 @@ static int testCPRGlobalAirborne() {
                     rlat, cprGlobalAirborneTests[i].even_rlat,
                     rlon, cprGlobalAirborneTests[i].even_rlon);
         } else {
-            fprintf(stderr, "testCPRGlobalAirborne[%u,EVEN]: PASS\n", i);
+            FPRINTF(stderr, "testCPRGlobalAirborne[%u,EVEN]: PASS\n", i);
         }
 
         res = decodeCPRairborne(cprGlobalAirborneTests[i].even_cprlat, cprGlobalAirborneTests[i].even_cprlon,
@@ -185,7 +185,7 @@ static int testCPRGlobalAirborne() {
             || fabs(rlat - cprGlobalAirborneTests[i].odd_rlat) > 1e-6
             || fabs(rlon - cprGlobalAirborneTests[i].odd_rlon) > 1e-6) {
             ok = 0;
-            fprintf(stderr,
+            FPRINTF(stderr,
                     "testCPRGlobalAirborne[%u,ODD]:  FAIL: decodeCPRairborne(%d,%d,%d,%d,ODD) failed:\n"
                     " result %d  (expected %d)\n"
                     " lat %.6f   (expected %.6f)\n"
@@ -197,7 +197,7 @@ static int testCPRGlobalAirborne() {
                     rlat, cprGlobalAirborneTests[i].odd_rlat,
                     rlon, cprGlobalAirborneTests[i].odd_rlon);
         } else {
-            fprintf(stderr, "testCPRGlobalAirborne[%u,ODD]:  PASS\n", i);
+            FPRINTF(stderr, "testCPRGlobalAirborne[%u,ODD]:  PASS\n", i);
         }
     }
 
@@ -220,7 +220,7 @@ static int testCPRGlobalSurface() {
             || fabs(rlat - cprGlobalSurfaceTests[i].even_rlat) > 1e-6
             || fabs(rlon - cprGlobalSurfaceTests[i].even_rlon) > 1e-6) {
             ok = 0;
-            fprintf(stderr,
+            FPRINTF(stderr,
                     "testCPRGlobalSurface[%u,EVEN]:  FAIL: decodeCPRsurface(%.6f,%.6f,%d,%d,%d,%d,EVEN) failed:\n"
                     " result %d  (expected %d)\n"
                     " lat %.6f   (expected %.6f)\n"
@@ -233,7 +233,7 @@ static int testCPRGlobalSurface() {
                     rlat, cprGlobalSurfaceTests[i].even_rlat,
                     rlon, cprGlobalSurfaceTests[i].even_rlon);
         } else {
-            fprintf(stderr, "testCPRGlobalSurface[%u,EVEN]:  PASS\n", i);
+            FPRINTF(stderr, "testCPRGlobalSurface[%u,EVEN]:  PASS\n", i);
         }
 
         res = decodeCPRsurface(cprGlobalSurfaceTests[i].reflat, cprGlobalSurfaceTests[i].reflon,
@@ -245,7 +245,7 @@ static int testCPRGlobalSurface() {
             || fabs(rlat - cprGlobalSurfaceTests[i].odd_rlat) > 1e-6
             || fabs(rlon - cprGlobalSurfaceTests[i].odd_rlon) > 1e-6) {
             ok = 0;
-            fprintf(stderr,
+            FPRINTF(stderr,
                     "testCPRGlobalSurface[%u,ODD]:   FAIL: decodeCPRsurface(%.6f,%.6f,%d,%d,%d,%d,ODD) failed:\n"
                     " result %d  (expected %d)\n"
                     " lat %.6f   (expected %.6f)\n"
@@ -258,7 +258,7 @@ static int testCPRGlobalSurface() {
                     rlat, cprGlobalSurfaceTests[i].odd_rlat,
                     rlon, cprGlobalSurfaceTests[i].odd_rlon);
         } else {
-            fprintf(stderr, "testCPRGlobalSurface[%u,ODD]:   PASS\n", i);
+            FPRINTF(stderr, "testCPRGlobalSurface[%u,ODD]:   PASS\n", i);
         }
     }
 
@@ -280,7 +280,7 @@ static int testCPRRelative() {
             || fabs(rlat - cprRelativeTests[i].rlat) > 1e-6
             || fabs(rlon - cprRelativeTests[i].rlon) > 1e-6) {
             ok = 0;
-            fprintf(stderr,
+            FPRINTF(stderr,
                     "testCPRRelative[%u]:  FAIL: decodeCPRrelative(%.6f,%.6f,%d,%d,%d,%d) failed:\n"
                     " result %d  (expected %d)\n"
                     " lat %.6f   (expected %.6f)\n"
@@ -293,7 +293,7 @@ static int testCPRRelative() {
                     rlat, cprRelativeTests[i].rlat,
                     rlon, cprRelativeTests[i].rlon);
         } else {
-            fprintf(stderr, "testCPRRelative[%u]:  PASS\n", i);
+            FPRINTF(stderr, "testCPRRelative[%u]:  PASS\n", i);
         }
     }
 

--- a/demod_2000.c
+++ b/demod_2000.c
@@ -4,20 +4,20 @@
 //
 // Copyright (c) 2014,2015 Oliver Jowett <oliver@mutability.co.uk>
 //
-// This file is free software: you may copy, redistribute and/or modify it  
+// This file is free software: you may copy, redistribute and/or modify it
 // under the terms of the GNU General Public License as published by the
-// Free Software Foundation, either version 2 of the License, or (at your  
-// option) any later version.  
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version.
 //
-// This file is distributed in the hope that it will be useful, but  
-// WITHOUT ANY WARRANTY; without even the implied warranty of  
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU  
+// This file is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 // General Public License for more details.
 //
-// You should have received a copy of the GNU General Public License  
+// You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-// This file incorporates work covered by the following copyright and  
+// This file incorporates work covered by the following copyright and
 // permission notice:
 //
 //   Copyright (C) 2012 by Salvatore Sanfilippo <antirez@gmail.com>
@@ -55,8 +55,8 @@
 // ===================== Mode A/C detection and decoding  ===================
 //
 //
-// This table is used to build the Mode A/C variable called ModeABits.Each 
-// bit period is inspected, and if it's value exceeds the threshold limit, 
+// This table is used to build the Mode A/C variable called ModeABits.Each
+// bit period is inspected, and if it's value exceeds the threshold limit,
 // then the value in this table is or-ed into ModeABits.
 //
 // At the end of message processing, ModeABits will be the decoded ModeA value.
@@ -69,12 +69,12 @@ uint32_t ModeABitTable[24] = {
 0x00000000, // F1 = 1
 0x00000010, // C1
 0x00001000, // A1
-0x00000020, // C2 
+0x00000020, // C2
 0x00002000, // A2
 0x00000040, // C4
 0x00004000, // A4
 0x40000000, // xx = 0  Set bit 30 if we see this high
-0x00000100, // B1 
+0x00000100, // B1
 0x00000001, // D1
 0x00000200, // B2
 0x00000002, // D2
@@ -92,12 +92,12 @@ uint32_t ModeABitTable[24] = {
 0x00100000, // xx = 0  Set bit 20 if we see this high
 };
 //
-// This table is used to produce an error variable called ModeAErrs.Each 
-// inter-bit period is inspected, and if it's value falls outside of the 
+// This table is used to produce an error variable called ModeAErrs.Each
+// inter-bit period is inspected, and if it's value falls outside of the
 // expected range, then the value in this table is or-ed into ModeAErrs.
 //
-// At the end of message processing, ModeAErrs will indicate if we saw 
-// any inter-bit anomolies, and the bits that are set will show which 
+// At the end of message processing, ModeAErrs will indicate if we saw
+// any inter-bit anomolies, and the bits that are set will show which
 // bits had them.
 //
 uint32_t ModeAMidTable[24] = {
@@ -131,36 +131,36 @@ uint32_t ModeAMidTable[24] = {
 // _F1_C1_A1_C2_A2_C4_A4_xx_B1_D1_B2_D2_B4_D4_F2_xx_xx_SPI_
 //
 // Bit spacing is 1.45uS, with 0.45uS high, and 1.00us low. This is a problem
-// because we ase sampling at 2Mhz (500nS) so we are below Nyquist. 
+// because we ase sampling at 2Mhz (500nS) so we are below Nyquist.
 //
 // The bit spacings are..
-// F1 :  0.00,   
-//       1.45,  2.90,  4.35,  5.80,  7.25,  8.70, 
-// X  : 10.15, 
-//    : 11.60, 13.05, 14.50, 15.95, 17.40, 18.85, 
-// F2 : 20.30, 
-// X  : 21.75, 23.20, 24.65 
+// F1 :  0.00,
+//       1.45,  2.90,  4.35,  5.80,  7.25,  8.70,
+// X  : 10.15,
+//    : 11.60, 13.05, 14.50, 15.95, 17.40, 18.85,
+// F2 : 20.30,
+// X  : 21.75, 23.20, 24.65
 //
 // This equates to the following sample point centers at 2Mhz.
-// [ 0.0], 
-// [ 2.9], [ 5.8], [ 8.7], [11.6], [14.5], [17.4], 
-// [20.3], 
+// [ 0.0],
+// [ 2.9], [ 5.8], [ 8.7], [11.6], [14.5], [17.4],
+// [20.3],
 // [23.2], [26.1], [29.0], [31.9], [34.8], [37.7]
 // [40.6]
 // [43.5], [46.4], [49.3]
 //
 // We know that this is a supposed to be a binary stream, so the signal
-// should either be a 1 or a 0. Therefore, any energy above the noise level 
-// in two adjacent samples must be from the same pulse, so we can simply 
-// add the values together.. 
-// 
+// should either be a 1 or a 0. Therefore, any energy above the noise level
+// in two adjacent samples must be from the same pulse, so we can simply
+// add the values together..
+//
 int detectModeA(uint16_t *m, struct modesMessage *mm)
   {
   int j, lastBitWasOne;
   int ModeABits = 0;
   int ModeAErrs = 0;
   int byte, bit;
-  int thisSample, lastBit, lastSpace = 0; 
+  int thisSample, lastBit, lastSpace = 0;
   int m0, m1, m2, m3, mPhase;
   int n0, n1, n2 ,n3;
   int F1_sig, F1_noise;
@@ -177,15 +177,15 @@ int detectModeA(uint16_t *m, struct modesMessage *mm)
   //
   // The width of the frame bit is 450nS, which is 90% of our sample rate.
   // Therefore, in an ideal world, all the energy for the frame bit will be
-  // in a single sample, preceeded by (at least) one zero, and followed by 
+  // in a single sample, preceeded by (at least) one zero, and followed by
   // two zeros, Best case we can look for ...
   //
   // 0 - 1 - 0 - 0
   //
-  // However, our samples are not phase aligned, so some of the energy from 
+  // However, our samples are not phase aligned, so some of the energy from
   // each bit could be spread over two consecutive samples. Worst case is
-  // that we sample half in one bit, and half in the next. In that case, 
-  // we're looking for 
+  // that we sample half in one bit, and half in the next. In that case,
+  // we're looking for
   //
   // 0 - 0.5 - 0.5 - 0.
 
@@ -196,8 +196,8 @@ int detectModeA(uint16_t *m, struct modesMessage *mm)
 
   m2 = m[2]; m3 = m[3];
 
-  // 
-  // if (m2 <= m0), then assume the sample bob on (Phase == 0), so don't look at m3 
+  //
+  // if (m2 <= m0), then assume the sample bob on (Phase == 0), so don't look at m3
   if ((m2 <= m0) || (m2 < m3))
     {m3 = m2; m2 = m0;}
 
@@ -211,7 +211,7 @@ int detectModeA(uint16_t *m, struct modesMessage *mm)
   // m2 = noise + (signal * (1-X))
   // m3 = noise
   //
-  // Hence, assuming all 4 samples have similar amounts of noise in them 
+  // Hence, assuming all 4 samples have similar amounts of noise in them
   //      signal = (m1 + m2) - ((m0 + m3) * 2)
   //      noise  = (m0 + m3) / 2
   //
@@ -224,19 +224,19 @@ int detectModeA(uint16_t *m, struct modesMessage *mm)
 
   // If we get here then we have a potential F1, so look for an equally valid F2 20.3uS later
   //
-  // Our F1 is centered somewhere between samples m[1] and m[2]. We can guestimate where F2 is 
+  // Our F1 is centered somewhere between samples m[1] and m[2]. We can guestimate where F2 is
   // by comparing the ratio of m1 and m2, and adding on 20.3 uS (40.6 samples)
   //
   mPhase = ((m2 * 20) / (m1 + m2));
-  byte   = (mPhase + 812) / 20; 
-  n0     = m[byte++]; n1 = m[byte++]; 
+  byte   = (mPhase + 812) / 20;
+  n0     = m[byte++]; n1 = m[byte++];
 
   if (n0 >= n1)   // n1 *must* be bigger than n0 for this to be F2
     {return (0);}
 
   n2 = m[byte++];
-  // 
-  // if the sample bob on (Phase == 0), don't look at n3 
+  //
+  // if the sample bob on (Phase == 0), don't look at n3
   //
   if ((mPhase + 812) % 20)
     {n3 = m[byte++];}
@@ -269,16 +269,16 @@ int detectModeA(uint16_t *m, struct modesMessage *mm)
   for (j = 1, mPhase += 29; j < 48; mPhase += 29, j ++)
     {
     byte  = 1 + (mPhase / 20);
-    
+
     thisSample = m[byte] - fNoise;
     if (mPhase % 20)                     // If the bit is split over two samples...
       {thisSample += (m[byte+1] - fNoise);}  //    add in the second sample's energy
 
      // If we're calculating a space value
-    if (j & 1)               
+    if (j & 1)
       {lastSpace = thisSample;}
 
-    else 
+    else
       {// We're calculating a new bit value
       bit = j >> 1;
       if (thisSample >= fLevel)
@@ -291,7 +291,7 @@ int detectModeA(uint16_t *m, struct modesMessage *mm)
             {ModeAErrs |= ModeAMidTable[bit];}
           }
 
-        else              
+        else
           {// This bit,is one, last bit was zero, so check the last space is somewhere less than one
           if (lastSpace >= (thisSample >> 1))
             {ModeAErrs |= ModeAMidTable[bit];}
@@ -300,8 +300,8 @@ int detectModeA(uint16_t *m, struct modesMessage *mm)
         lastBitWasOne = 1;
         }
 
-      
-      else 
+
+      else
         {// We're calculating a new bit value, and its a zero
         if (lastBitWasOne)
           { // This bit is zero, last bit was one, so check the last space is somewhere in between
@@ -309,16 +309,16 @@ int detectModeA(uint16_t *m, struct modesMessage *mm)
             {ModeAErrs |= ModeAMidTable[bit];}
           }
 
-        else              
+        else
           {// This bit,is zero, last bit was zero, so check the last space is zero too
           if (lastSpace >= fLoLo)
             {ModeAErrs |= ModeAMidTable[bit];}
           }
 
-        lastBitWasOne = 0;   
+        lastBitWasOne = 0;
         }
 
-      lastBit = (thisSample >> 1); 
+      lastBit = (thisSample >> 1);
       }
     }
 
@@ -400,22 +400,22 @@ static void dumpRawMessageJS(char *descr, unsigned char *msg,
     int j;
 
     if ((fp = fopen("frames.js","a")) == NULL) {
-        fprintf(stderr, "Error opening frames.js: %s\n", strerror(errno));
+        FPRINTF(stderr, "Error opening frames.js: %s\n", strerror(errno));
         exit(1);
     }
 
-    fprintf(fp,"frames.push({\"descr\": \"%s\", \"mag\": [", descr);
+    FPRINTF(fp,"frames.push({\"descr\": \"%s\", \"mag\": [", descr);
     for (j = start; j <= end; j++) {
-        fprintf(fp,"%d", j < 0 ? 0 : m[j]);
-        if (j != end) fprintf(fp,",");
+        FPRINTF(fp,"%d", j < 0 ? 0 : m[j]);
+        if (j != end) FPRINTF(fp,",");
     }
-    fprintf(fp, "], ");
+    FPRINTF(fp, "], ");
     for (j = 0; j < MODES_MAX_BITERRORS; ++j)
-        fprintf(fp,"\"fix%d\": %d, ", j, ei->bit[j]);
-    fprintf(fp, "\"bits\": %d, \"hex\": \"", modesMessageLenByType(msg[0]>>3));
+        FPRINTF(fp,"\"fix%d\": %d, ", j, ei->bit[j]);
+    FPRINTF(fp, "\"bits\": %d, \"hex\": \"", modesMessageLenByType(msg[0]>>3));
     for (j = 0; j < MODES_LONG_MSG_BYTES; j++)
-        fprintf(fp,"\\x%02x",msg[j]);
-    fprintf(fp,"\"});\n");
+        FPRINTF(fp,"\\x%02x",msg[j]);
+    FPRINTF(fp,"\"});\n");
     fclose(fp);
 }
 //
@@ -578,7 +578,7 @@ void demodulate2000(struct mag_buf *mag) {
     // 1.0 - 1.5 usec: second impulse.
     // 3.5 - 4   usec: third impulse.
     // 4.5 - 5   usec: last impulse.
-    // 
+    //
     // Since we are sampling at 2 Mhz every sample in our magnitude vector
     // is 0.5 usec, so the preamble will look like this, assuming there is
     // an impulse at offset 0 in the array:
@@ -595,7 +595,7 @@ void demodulate2000(struct mag_buf *mag) {
     // 9   -------------------
     //
     for (j = 0; j < mlen; j++) {
-        int high, i, errors, errors56, errorsTy; 
+        int high, i, errors, errors56, errorsTy;
         uint16_t *pPreamble, *pPayload, *pPtr;
         uint8_t  theByte, theErrs;
         int msglen, scanlen;
@@ -615,11 +615,11 @@ void demodulate2000(struct mag_buf *mag) {
         if (!use_correction)  // This is not a re-try with phase correction
             {                 // so try to find a new preamble
 
-            if (Modes.mode_ac) 
+            if (Modes.mode_ac)
                 {
                 int ModeA = detectModeA(pPreamble, &mm);
 
-                if (ModeA) // We have found a valid ModeA/C in the data                    
+                if (ModeA) // We have found a valid ModeA/C in the data
                     {
                     mm.timestampMsg = mag->sampleTimestamp + ((j+1) * 6);
 
@@ -688,7 +688,7 @@ void demodulate2000(struct mag_buf *mag) {
                 continue;
             }
             Modes.stats_current.demod_preambles++;
-        } 
+        }
 
         else {
             // If the previous attempt with this message failed, retry using
@@ -708,8 +708,8 @@ void demodulate2000(struct mag_buf *mag) {
         theErrs = 0; errorsTy = 0;
         errors  = 0; errors56 = 0;
 
-        // We should have 4 'bits' of 0/1 and 1/0 samples in the preamble, 
-        // so include these in the signal strength 
+        // We should have 4 'bits' of 0/1 and 1/0 samples in the preamble,
+        // so include these in the signal strength
         sigLevel = pPreamble[0] + pPreamble[2] + pPreamble[7] + pPreamble[9];
         noiseLevel = pPreamble[1] + pPreamble[3] + pPreamble[4] + pPreamble[6] + pPreamble[8];
 
@@ -718,9 +718,9 @@ void demodulate2000(struct mag_buf *mag) {
             uint32_t a = *pPtr++;
             uint32_t b = *pPtr++;
 
-            if      (a > b) 
+            if      (a > b)
                 {theByte |= 1; if (i < 56) { sigLevel += a; noiseLevel += b; }}
-            else if (a < b) 
+            else if (a < b)
                 {/*theByte |= 0;*/ if (i < 56) { sigLevel += b; noiseLevel += a; }}
             else {
                 if (i < 56) { sigLevel += a; noiseLevel += a; }
@@ -734,7 +734,7 @@ void demodulate2000(struct mag_buf *mag) {
                     {errorsTy = errors56 = ++errors; theErrs |= 1; theByte |= 1;}
             }
 
-            if ((i & 7) == 7) 
+            if ((i & 7) == 7)
               {*pMsg++ = theByte;}
             else if (i == 4) {
               msglen  = modesMessageLenByType(theByte);
@@ -753,12 +753,12 @@ void demodulate2000(struct mag_buf *mag) {
                     msglen = 0;
 
                 } else if ((errorsTy == 1) && (theErrs == 0x80)) {
-                    // If we only saw one error in the first bit of the byte of the frame, then it's possible 
+                    // If we only saw one error in the first bit of the byte of the frame, then it's possible
                     // we guessed wrongly about the value of the bit. We may be able to correct it by guessing
                     // the other way.
                     //
                     // We guessed a '1' at bit 7, which is the DF length bit == 112 Bits.
-                    // Inverting bit 7 will change the message type from a long to a short. 
+                    // Inverting bit 7 will change the message type from a long to a short.
                     // Invert the bit, cross your fingers and carry on.
                     msglen  = MODES_SHORT_MSG_BITS;
                     msg[0] ^= theErrs; errorsTy = 0;
@@ -789,20 +789,20 @@ void demodulate2000(struct mag_buf *mag) {
         // message types. If it isn't then toggle the guessed bit and see if this new value is ICAO defined.
         // if the new value is ICAO defined, then update it in our message.
         if ((msglen) && (errorsTy == 1) && (theErrs & 0x78)) {
-            // We guessed at one (and only one) of the message type bits. See if our guess is "likely" 
+            // We guessed at one (and only one) of the message type bits. See if our guess is "likely"
             // to be correct by comparing the DF against a list of known good DF's
             int      thisDF      = ((theByte = msg[0]) >> 3) & 0x1f;
             uint32_t validDFbits = 0x017F0831;   // One bit per 32 possible DF's. Set bits 0,4,5,11,16.17.18.19,20,21,22,24
             uint32_t thisDFbit   = (1 << thisDF);
             if (0 == (validDFbits & thisDFbit)) {
-                // The current DF is not ICAO defined, so is probably an errors. 
+                // The current DF is not ICAO defined, so is probably an errors.
                 // Toggle the bit we guessed at and see if the resultant DF is more likely
                 theByte  ^= theErrs;
                 thisDF    = (theByte >> 3) & 0x1f;
                 thisDFbit = (1 << thisDF);
                 // if this DF any more likely?
                 if (validDFbits & thisDFbit) {
-                    // Yep, more likely, so update the main message 
+                    // Yep, more likely, so update the main message
                     msg[0] = theByte;
                     errors--; // decrease the error count so we attempt to use the modified DF.
                 }
@@ -819,9 +819,9 @@ void demodulate2000(struct mag_buf *mag) {
         snr = Modes.log10lut[sigLevel] - Modes.log10lut[noiseLevel];
 
         // When we reach this point, if error is small, and the signal strength is large enough
-        // we may have a Mode S message on our hands. It may still be broken and the CRC may not 
+        // we may have a Mode S message on our hands. It may still be broken and the CRC may not
         // be correct, but this can be handled by the next layer.
-        if ( (msglen) 
+        if ( (msglen)
           && ((2 * snr) > (int) (MODES_MSG_SQUELCH_DB * 10))
           && (errors      <= MODES_MSG_ENCODER_ERRS) ) {
             int result;
@@ -860,7 +860,7 @@ void demodulate2000(struct mag_buf *mag) {
                          (!message_ok || mm.correctedbits > 0))
                     dumpRawMessage("Decoded with bad CRC", msg, m, j);
                 else if (Modes.debug & MODES_DEBUG_GOODCRC &&
-                         message_ok && 
+                         message_ok &&
                          mm.correctedbits == 0)
                     dumpRawMessage("Decoded with good CRC", msg, m, j);
             }
@@ -884,7 +884,7 @@ void demodulate2000(struct mag_buf *mag) {
         if (Modes.phase_enhance && (!message_ok || mm.correctedbits > 0) && !use_correction && j && detectOutOfPhase(pPreamble)) {
             use_correction = 1; j--;
         } else {
-            use_correction = 0; 
+            use_correction = 0;
         }
     }
 }

--- a/demod_2400.c
+++ b/demod_2400.c
@@ -4,17 +4,17 @@
 //
 // Copyright (c) 2014,2015 Oliver Jowett <oliver@mutability.co.uk>
 //
-// This file is free software: you may copy, redistribute and/or modify it  
+// This file is free software: you may copy, redistribute and/or modify it
 // under the terms of the GNU General Public License as published by the
-// Free Software Foundation, either version 2 of the License, or (at your  
-// option) any later version.  
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version.
 //
-// This file is distributed in the hope that it will be useful, but  
-// WITHOUT ANY WARRANTY; without even the implied warranty of  
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU  
+// This file is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 // General Public License for more details.
 //
-// You should have received a copy of the GNU General Public License  
+// You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "dump1090.h"
@@ -185,7 +185,7 @@ void demodulate2400(struct mag_buf *mag)
         // phase 6: 0/4\2 2/4\0 0 0 0 2/4\0/5\1 0 0 0 0 0 0 X2
         // phase 7: 0/3 3\1/5\0 0 0 0 1/5\0/4\2 0 0 0 0 0 0 X3
         //
-        
+
         // quick check: we must have a rising edge 0->1 and a falling edge 12->13
         if (! (preamble[0] < preamble[1] && preamble[12] > preamble[13]) )
            continue;
@@ -261,7 +261,7 @@ void demodulate2400(struct mag_buf *mag)
             if (initial_phase < 0) {
                 continue; // nothing satisfactory
             }
-            
+
             first_phase = last_phase = initial_phase;  // try only the phase we think it is
         }
 
@@ -273,7 +273,7 @@ void demodulate2400(struct mag_buf *mag)
 
             // Decode all the next 112 bits, regardless of the actual message
             // size. We'll check the actual message type later
-            
+
             pPtr = &m[j+19] + (try_phase/5);
             phase = try_phase % 5;
 
@@ -283,7 +283,7 @@ void demodulate2400(struct mag_buf *mag)
 
                 switch (phase) {
                 case 0:
-                    theByte = 
+                    theByte =
                         (slice_phase0(pPtr) > 0 ? 0x80 : 0) |
                         (slice_phase2(pPtr+2) > 0 ? 0x40 : 0) |
                         (slice_phase4(pPtr+4) > 0 ? 0x20 : 0) |
@@ -297,7 +297,7 @@ void demodulate2400(struct mag_buf *mag)
                     phase = 1;
                     pPtr += 19;
                     break;
-                    
+
                 case 1:
                     theByte =
                         (slice_phase1(pPtr) > 0 ? 0x80 : 0) |
@@ -312,7 +312,7 @@ void demodulate2400(struct mag_buf *mag)
                     phase = 2;
                     pPtr += 19;
                     break;
-                    
+
                 case 2:
                     theByte =
                         (slice_phase2(pPtr) > 0 ? 0x80 : 0) |
@@ -327,9 +327,9 @@ void demodulate2400(struct mag_buf *mag)
                     phase = 3;
                     pPtr += 19;
                     break;
-                    
+
                 case 3:
-                    theByte = 
+                    theByte =
                         (slice_phase3(pPtr) > 0 ? 0x80 : 0) |
                         (slice_phase0(pPtr+3) > 0 ? 0x40 : 0) |
                         (slice_phase2(pPtr+5) > 0 ? 0x20 : 0) |
@@ -342,9 +342,9 @@ void demodulate2400(struct mag_buf *mag)
                     phase = 4;
                     pPtr += 19;
                     break;
-                    
+
                 case 4:
-                    theByte = 
+                    theByte =
                         (slice_phase4(pPtr) > 0 ? 0x80 : 0) |
                         (slice_phase1(pPtr+3) > 0 ? 0x40 : 0) |
                         (slice_phase3(pPtr+5) > 0 ? 0x20 : 0) |
@@ -364,7 +364,7 @@ void demodulate2400(struct mag_buf *mag)
                     switch (msg[0] >> 3) {
                     case 0: case 4: case 5: case 11:
                         bytelen = MODES_SHORT_MSG_BYTES; break;
-                        
+
                     case 16: case 17: case 18: case 20: case 21: case 24:
                         break;
 
@@ -382,7 +382,7 @@ void demodulate2400(struct mag_buf *mag)
                 bestmsg = msg;
                 bestscore = score;
                 bestphase = try_phase;
-                
+
                 // swap to using the other buffer so we don't clobber our demodulated data
                 // (if we find a better result then we'll swap back, but that's OK because
                 // we no longer need this copy if we found a better one)
@@ -457,7 +457,7 @@ void demodulate2400(struct mag_buf *mag)
         //  few bits of the first message, but the message bits didn't
         //  overlap)
         j += msglen*12/5;
-            
+
         // Pass data to the next layer
         useModesMessage(&mm);
     }
@@ -637,10 +637,10 @@ void demodulate2400AC(struct mag_buf *mag)
         unsigned signal_threshold = (unsigned) (midpoint * 1.414214 + 0.5); // +3dB from midpoint
 
 #if 0
-        fprintf(stderr, "f1f2 %u x1x2x3 %u midpoint %.0f noise_threshold %u signal_threshold %u\n",
+        FPRINTF(stderr, "f1f2 %u x1x2x3 %u midpoint %.0f noise_threshold %u signal_threshold %u\n",
                 f1f2_signal, x1x2x3_noise, midpoint, noise_threshold, signal_threshold);
 
-        fprintf(stderr, "f1 %u f2 %u x1 %u x2 %u x3 %u\n",
+        FPRINTF(stderr, "f1 %u f2 %u x1 %u x2 %u x3 %u\n",
                 f1_signal, f2_signal, x1_noise, x2_noise, x3_noise);
 #endif
 
@@ -669,7 +669,7 @@ void demodulate2400AC(struct mag_buf *mag)
 
             // check for excessive noise in the quiet period
             if (m[sample+2] >= noise_threshold) {
-                //fprintf(stderr, "bit %u was not quiet (%u > %u)\n", bit, m[sample+2], signal_threshold);
+                //FPRINTF(stderr, "bit %u was not quiet (%u > %u)\n", bit, m[sample+2], signal_threshold);
                 noisy_bits |= 1;
                 continue;
             }
@@ -680,7 +680,7 @@ void demodulate2400AC(struct mag_buf *mag)
                 bits |= 1;
             } else if (bit_signal > noise_threshold) {
                 /* not certain about this bit */
-                //fprintf(stderr, "bit %u was uncertain (%u < %u < %u)\n", bit, noise_threshold, bit_signal, signal_threshold);
+                //FPRINTF(stderr, "bit %u was uncertain (%u < %u < %u)\n", bit, noise_threshold, bit_signal, signal_threshold);
                 noisy_bits |= 1;
             } else {
                 /* this bit is off */
@@ -688,7 +688,7 @@ void demodulate2400AC(struct mag_buf *mag)
         }
 
 #if 0
-        fprintf(stderr, "bits: %06X  noisy: %06X\n", bits, noisy_bits);
+        FPRINTF(stderr, "bits: %06X  noisy: %06X\n", bits, noisy_bits);
 
         unsigned j, sample;
         static const char *names[24] = {
@@ -700,17 +700,17 @@ void demodulate2400AC(struct mag_buf *mag)
             "X6", "X7", "X8", "X9"
         };
 
-        fprintf(stderr, "-1 ... %6u\n", m[f1_sample-1]);
+        FPRINTF(stderr, "-1 ... %6u\n", m[f1_sample-1]);
         for (j = 0; j < 24; ++j) {
             clock = f1_clock + 87 * j;
             sample = clock / 25;
-            fprintf(stderr, "%2u %-3s %6u %6u %6u %6u ", j, names[j], m[sample+0], m[sample+1], m[sample+2], m[sample+3]);
+            FPRINTF(stderr, "%2u %-3s %6u %6u %6u %6u ", j, names[j], m[sample+0], m[sample+1], m[sample+2], m[sample+3]);
             if ((m[sample+0] + m[sample+1])/2 >= signal_threshold) {
-                fprintf(stderr, "ON\n");
+                FPRINTF(stderr, "ON\n");
             } else if ((m[sample+0] + m[sample+1])/2 <= noise_threshold) {
-                fprintf(stderr, "OFF\n");
+                FPRINTF(stderr, "OFF\n");
             } else {
-                fprintf(stderr, "UNCERTAIN\n");
+                FPRINTF(stderr, "UNCERTAIN\n");
             }
         }
 #endif

--- a/dump1090.c
+++ b/dump1090.c
@@ -287,8 +287,9 @@ static void convert_samples(void *iq,
 //
 
 #ifdef BUILD_LIB
-int dev_index;
+static int dev_index;
 #endif
+
 int modesInitRTLSDR(void) {
 #ifndef BUILD_LIB
 

--- a/dump1090.h
+++ b/dump1090.h
@@ -4,20 +4,20 @@
 //
 // Copyright (c) 2014,2015 Oliver Jowett <oliver@mutability.co.uk>
 //
-// This file is free software: you may copy, redistribute and/or modify it  
+// This file is free software: you may copy, redistribute and/or modify it
 // under the terms of the GNU General Public License as published by the
-// Free Software Foundation, either version 2 of the License, or (at your  
-// option) any later version.  
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version.
 //
-// This file is distributed in the hope that it will be useful, but  
-// WITHOUT ANY WARRANTY; without even the implied warranty of  
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU  
+// This file is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 // General Public License for more details.
 //
-// You should have received a copy of the GNU General Public License  
+// You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-// This file incorporates work covered by the following copyright and  
+// This file incorporates work covered by the following copyright and
 // permission notice:
 //
 //   Copyright (C) 2012 by Salvatore Sanfilippo <antirez@gmail.com>
@@ -358,10 +358,10 @@ struct modesMessage {
     // Generic fields
     unsigned char msg[MODES_LONG_MSG_BYTES];      // Binary message.
     unsigned char verbatim[MODES_LONG_MSG_BYTES]; // Binary message, as originally received before correction
-    int           msgbits;                        // Number of bits in message 
+    int           msgbits;                        // Number of bits in message
     int           msgtype;                        // Downlink format #
     uint32_t      crc;                            // Message CRC
-    int           correctedbits;                  // No. of bits corrected 
+    int           correctedbits;                  // No. of bits corrected
     uint32_t      addr;                           // Address Announced
     uint64_t      timestampMsg;                   // Timestamp of the message (12MHz clock)
     struct timespec sysTimestampMsg;              // Timestamp of the message (system time)
@@ -404,9 +404,15 @@ struct modesMessage {
 
     // Fields used by multiple message types.
     int  altitude;
-    int  unit; 
+    int  unit;
     int  bFlags;                // Flags related to fields in this structure
 };
+
+#ifdef BUILD_LIB
+#define FPRINTF(f, fmt, ...) stratuxLog(fmt, ##__VA_ARGS__)
+#else
+#define FPRINTF(f, ...) fprintf(f, __VA_ARGS__)
+#endif
 
 // This one needs modesMessage:
 #include "track.h"
@@ -415,6 +421,11 @@ struct modesMessage {
 
 #ifdef __cplusplus
 extern "C" {
+#endif
+
+#ifdef BUILD_LIB
+void stratux_log(char *fmt, ...);
+#include "stratux_exports.h"
 #endif
 
 //

--- a/faup1090.c
+++ b/faup1090.c
@@ -4,20 +4,20 @@
 //
 // Copyright (c) 2014,2015 Oliver Jowett <oliver@mutability.co.uk>
 //
-// This file is free software: you may copy, redistribute and/or modify it  
+// This file is free software: you may copy, redistribute and/or modify it
 // under the terms of the GNU General Public License as published by the
-// Free Software Foundation, either version 2 of the License, or (at your  
-// option) any later version.  
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version.
 //
-// This file is distributed in the hope that it will be useful, but  
-// WITHOUT ANY WARRANTY; without even the implied warranty of  
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU  
+// This file is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 // General Public License for more details.
 //
-// You should have received a copy of the GNU General Public License  
+// You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-// This file incorporates work covered by the following copyright and  
+// This file incorporates work covered by the following copyright and
 // permission notice:
 //
 //   Copyright (C) 2012 by Salvatore Sanfilippo <antirez@gmail.com>
@@ -75,17 +75,17 @@ static void faupInitConfig(void) {
 static void faupInit(void) {
     // Validate the users Lat/Lon home location inputs
     if ( (Modes.fUserLat >   90.0)  // Latitude must be -90 to +90
-      || (Modes.fUserLat <  -90.0)  // and 
+      || (Modes.fUserLat <  -90.0)  // and
       || (Modes.fUserLon >  360.0)  // Longitude must be -180 to +360
       || (Modes.fUserLon < -180.0) ) {
         Modes.fUserLat = Modes.fUserLon = 0.0;
     } else if (Modes.fUserLon > 180.0) { // If Longitude is +180 to +360, make it -180 to 0
         Modes.fUserLon -= 360.0;
     }
-    // If both Lat and Lon are 0.0 then the users location is either invalid/not-set, or (s)he's in the 
-    // Atlantic ocean off the west coast of Africa. This is unlikely to be correct. 
-    // Set the user LatLon valid flag only if either Lat or Lon are non zero. Note the Greenwich meridian 
-    // is at 0.0 Lon,so we must check for either fLat or fLon being non zero not both. 
+    // If both Lat and Lon are 0.0 then the users location is either invalid/not-set, or (s)he's in the
+    // Atlantic ocean off the west coast of Africa. This is unlikely to be correct.
+    // Set the user LatLon valid flag only if either Lat or Lon are non zero. Note the Greenwich meridian
+    // is at 0.0 Lon,so we must check for either fLat or fLon being non zero not both.
     // Testing the flag at runtime will be much quicker than ((fLon != 0.0) || (fLat != 0.0))
     Modes.bUserFlags &= ~MODES_USER_LATLON_VALID;
     if ((Modes.fUserLat != 0.0) || (Modes.fUserLon != 0.0)) {
@@ -166,7 +166,7 @@ int main(int argc, char **argv) {
         } else if (!strcmp(argv[j],"--stdout")) {
             stdout_option = 1;
         } else {
-            fprintf(stderr,
+            FPRINTF(stderr,
                 "Unknown or not enough arguments for option '%s'.\n\n",
                 argv[j]);
             showHelp();
@@ -175,7 +175,7 @@ int main(int argc, char **argv) {
     }
 
     if (!stdout_option) {
-        fprintf(stderr,
+        FPRINTF(stderr,
                 "--stdout is required, output always goes to stdout.\n");
             showHelp();
         exit(1);
@@ -189,7 +189,7 @@ int main(int argc, char **argv) {
     beast_input = makeBeastInputService();
     c = serviceConnect(beast_input, bo_connect_ipaddr, bo_connect_port);
     if (!c) {
-        fprintf (stderr,
+        FPRINTF (stderr,
                  "faup1090: failed to connect to %s:%d (is dump1090 running?): %s\n",
                  bo_connect_ipaddr, bo_connect_port, Modes.aneterr);
         exit (1);

--- a/icao_filter.c
+++ b/icao_filter.c
@@ -4,17 +4,17 @@
 //
 // Copyright (c) 2014,2015 Oliver Jowett <oliver@mutability.co.uk>
 //
-// This file is free software: you may copy, redistribute and/or modify it  
+// This file is free software: you may copy, redistribute and/or modify it
 // under the terms of the GNU General Public License as published by the
-// Free Software Foundation, either version 2 of the License, or (at your  
-// option) any later version.  
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version.
 //
-// This file is distributed in the hope that it will be useful, but  
-// WITHOUT ANY WARRANTY; without even the implied warranty of  
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU  
+// This file is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 // General Public License for more details.
 //
-// You should have received a copy of the GNU General Public License  
+// You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "dump1090.h"
@@ -51,7 +51,7 @@ static uint32_t icaoHash(uint32_t a)
     hash += (a >> 16) & 0xff;
     hash += (hash << 10);
     hash ^= (hash >> 6);
-             
+
     hash += (hash << 3);
     hash ^= (hash >> 11);
     hash += (hash << 15);
@@ -73,7 +73,7 @@ void icaoFilterAdd(uint32_t addr)
     while (icao_filter_active[h] && icao_filter_active[h] != addr) {
         h = (h+1) & (ICAO_FILTER_SIZE-1);
         if (h == h0) {
-            fprintf(stderr, "ICAO hash table full, increase ICAO_FILTER_SIZE\n");
+            FPRINTF(stderr, "ICAO hash table full, increase ICAO_FILTER_SIZE\n");
             return;
         }
     }
@@ -85,7 +85,7 @@ void icaoFilterAdd(uint32_t addr)
     while (icao_filter_active[h] && (icao_filter_active[h] & 0x00ffff) != (addr & 0x00ffff)) {
         h = (h+1) & (ICAO_FILTER_SIZE-1);
         if (h == h0) {
-            fprintf(stderr, "ICAO hash table full, increase ICAO_FILTER_SIZE\n");
+            FPRINTF(stderr, "ICAO hash table full, increase ICAO_FILTER_SIZE\n");
             return;
         }
     }

--- a/net_io.c
+++ b/net_io.c
@@ -4,20 +4,20 @@
 //
 // Copyright (c) 2014,2015 Oliver Jowett <oliver@mutability.co.uk>
 //
-// This file is free software: you may copy, redistribute and/or modify it  
+// This file is free software: you may copy, redistribute and/or modify it
 // under the terms of the GNU General Public License as published by the
-// Free Software Foundation, either version 2 of the License, or (at your  
-// option) any later version.  
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version.
 //
-// This file is distributed in the hope that it will be useful, but  
-// WITHOUT ANY WARRANTY; without even the implied warranty of  
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU  
+// This file is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 // General Public License for more details.
 //
-// You should have received a copy of the GNU General Public License  
+// You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-// This file incorporates work covered by the following copyright and  
+// This file incorporates work covered by the following copyright and
 // permission notice:
 //
 //   Copyright (C) 2012 by Salvatore Sanfilippo <antirez@gmail.com>
@@ -89,7 +89,7 @@ struct net_service *serviceInit(const char *descr, struct net_writer *writer, he
     struct net_service *service;
 
     if (!(service = calloc(sizeof(*service), 1))) {
-        fprintf(stderr, "Out of memory allocating service %s\n", descr);
+        FPRINTF(stderr, "Out of memory allocating service %s\n", descr);
         exit(1);
     }
 
@@ -105,7 +105,7 @@ struct net_service *serviceInit(const char *descr, struct net_writer *writer, he
 
     if (service->writer) {
         if (! (service->writer->data = malloc(MODES_OUT_BUF_SIZE)) ) {
-            fprintf(stderr, "Out of memory allocating output buffer for service %s\n", descr);
+            FPRINTF(stderr, "Out of memory allocating output buffer for service %s\n", descr);
             exit(1);
         }
 
@@ -133,7 +133,7 @@ struct client *createGenericClient(struct net_service *service, int fd)
     anetNonBlock(Modes.aneterr, fd);
 
     if (!(c = (struct client *) malloc(sizeof(*c)))) {
-        fprintf(stderr, "Out of memory allocating a new %s network client\n", service->descr);
+        FPRINTF(stderr, "Out of memory allocating a new %s network client\n", service->descr);
         exit(1);
     }
 
@@ -177,7 +177,7 @@ void serviceListen(struct net_service *service, char *bind_addr, char *bind_port
     char buf[128];
 
     if (service->listener_count > 0) {
-        fprintf(stderr, "Tried to set up the service %s twice!\n", service->descr);
+        FPRINTF(stderr, "Tried to set up the service %s twice!\n", service->descr);
         exit(1);
     }
 
@@ -205,14 +205,14 @@ void serviceListen(struct net_service *service, char *bind_addr, char *bind_port
 
         nfds = anetTcpServer(Modes.aneterr, buf, bind_addr, newfds, sizeof(newfds));
         if (nfds == ANET_ERR) {
-            fprintf(stderr, "Error opening the listening port %s (%s): %s\n",
+            FPRINTF(stderr, "Error opening the listening port %s (%s): %s\n",
                     buf, service->descr, Modes.aneterr);
             exit(1);
         }
 
         fds = realloc(fds, (n+nfds) * sizeof(int));
         if (!fds) {
-            fprintf(stderr, "out of memory\n");
+            FPRINTF(stderr, "out of memory\n");
             exit(1);
         }
 
@@ -255,7 +255,7 @@ void modesInitNet(void) {
 
     s = serviceInit("Stratux TCP output", &Modes.stratux_out, send_stratux_heartbeat, NULL, NULL);
     serviceListen(s, Modes.net_bind_address, Modes.net_output_stratux_ports);
-    
+
     s = serviceInit("Raw TCP input", NULL, NULL, "\n", decodeHexMessage);
     serviceListen(s, Modes.net_bind_address, Modes.net_input_raw_ports);
 
@@ -293,7 +293,7 @@ static struct client * modesAcceptClients(void) {
 //
 static void modesCloseClient(struct client *c) {
     if (!c->service) {
-        fprintf(stderr, "warning: double close of net client\n");
+        FPRINTF(stderr, "warning: double close of net client\n");
         return;
     }
 
@@ -545,7 +545,7 @@ static void modesSendSBSOutput(struct modesMessage *mm, struct aircraft *a) {
     }
 
     // Fields 1 to 6 : SBS message type and ICAO address of the aircraft and some other stuff
-    p += sprintf(p, "MSG,%d,111,11111,%06X,111111,", msgType, mm->addr); 
+    p += sprintf(p, "MSG,%d,111,11111,%06X,111111,", msgType, mm->addr);
 
     // Find current system time
     clock_gettime(CLOCK_REALTIME, &now);
@@ -585,10 +585,10 @@ static void modesSendSBSOutput(struct modesMessage *mm, struct aircraft *a) {
     if (mm->bFlags & MODES_ACFLAGS_SPEED_VALID) {
         p += sprintf(p, ",%d", mm->velocity);
     } else {
-        p += sprintf(p, ","); 
+        p += sprintf(p, ",");
     }
 
-    // Field 14 is the ground Heading (if we have it)       
+    // Field 14 is the ground Heading (if we have it)
     if (mm->bFlags & MODES_ACFLAGS_HEADING_VALID) {
         p += sprintf(p, ",%d", mm->heading);
     } else {
@@ -696,7 +696,7 @@ static void modesSendStratuxOutput(struct modesMessage *mm, struct aircraft *a) 
     if (!p)
         return;
 
-    
+
     // Decide on the basic SBS Message Type
     if        ((mm->msgtype ==  4) || (mm->msgtype == 20)) {
         msgType = 5;
@@ -732,27 +732,27 @@ static void modesSendStratuxOutput(struct modesMessage *mm, struct aircraft *a) 
 
     // Begin populating fields.
 	// ICAO address, Mode S message types, and signal level
-    
+
     int cacf = 0; // overload the JSON "CA" field to report CA (DF11 or DF17), CF (DF18), or zero (all other DF types)
     if ((mm->msgtype == 11) || (mm->msgtype == 17)) {
         cacf = mm->ca;
     } else if (mm->msgtype == 18) {
         cacf = mm->cf;
     }
-    
-	p += sprintf(p, "{\"Icao_addr\":%d,\"DF\":%d,\"CA\":%d,\"TypeCode\":%d,\"SubtypeCode\":%d,\"SBS_MsgType\":%d,\"SignalLevel\":%f,",mm->addr, mm->msgtype, cacf, mm->metype,  mm->mesub, msgType, mm->signalLevel); 
-    
+
+	p += sprintf(p, "{\"Icao_addr\":%d,\"DF\":%d,\"CA\":%d,\"TypeCode\":%d,\"SubtypeCode\":%d,\"SBS_MsgType\":%d,\"SignalLevel\":%f,",mm->addr, mm->msgtype, cacf, mm->metype,  mm->mesub, msgType, mm->signalLevel);
+
  	// Callsign
 	if (mm->bFlags & MODES_ACFLAGS_CALLSIGN_VALID) {
 		p += sprintf(p, "\"Tail\":\"%s\",", mm->flight);
 	} else {
 		p += sprintf(p, "\"Tail\":null,");
-	}   
-    
+	}
+
     //Squawk code, decimal representation. E.g. the emergency code is represented as 7700 (0x1e14 == 017024), not 4032 (0x0FC0 == 07700)
     if (mm->bFlags & MODES_ACFLAGS_SQUAWK_VALID) {p += sprintf(p, "\"Squawk\":%x,", mm->modeA);}
-    else                                         {p += sprintf(p, "\"Squawk\":null,");}    
-    
+    else                                         {p += sprintf(p, "\"Squawk\":null,");}
+
     // Emitter type
 	int emitter = 0;
 	int setEmitter = 0;
@@ -772,13 +772,13 @@ static void modesSendStratuxOutput(struct modesMessage *mm, struct aircraft *a) 
 				setEmitter = 1;
 		}
 	}
-	
+
 	if (setEmitter) {
 		p += sprintf(p, "\"Emitter_category\":%d,", emitter);
 	} else {
 		p += sprintf(p, "\"Emitter_category\":null,");
 	}
-    
+
     // OnGround status
     if (mm->bFlags & MODES_ACFLAGS_AOG_VALID) {
         if (mm->bFlags & MODES_ACFLAGS_AOG) {
@@ -789,32 +789,32 @@ static void modesSendStratuxOutput(struct modesMessage *mm, struct aircraft *a) 
     } else {
         p += sprintf(p, "\"OnGround\":null,");
     }
-    
+
     // Position and position valid flag
 	if (mm->bFlags & MODES_ACFLAGS_LATLON_VALID) {
 		p += sprintf(p, "\"Lat\":%.6f,\"Lng\":%.6f,\"Position_valid\":true,",mm->fLat, mm->fLon);
 	} else {
 		p += sprintf(p, "\"Lat\":null,\"Lng\":null,\"Position_valid\":false,");
 	}
-	
+
     // Navigation Accuracy Category - Position
     if (mm->bFlags & MODES_ACFLAGS_OP_STATUS_VALID) {
         p += sprintf(p, "\"NACp\":%d,", mm->nacp);
     } else {
 	    p += sprintf(p, "\"NACp\":null,");
-    }  
-    
+    }
+
 	// Altitude
-	if ((mm->bFlags & MODES_ACFLAGS_AOG_GROUND) == MODES_ACFLAGS_AOG_GROUND) {  
+	if ((mm->bFlags & MODES_ACFLAGS_AOG_GROUND) == MODES_ACFLAGS_AOG_GROUND) {
         p += sprintf(p, "\"Alt\":0,");
     } else if (mm->bFlags & MODES_ACFLAGS_ALTITUDE_VALID) {
 		p += sprintf(p, "\"Alt\":%d,",mm->altitude);
     } else {
 		p += sprintf(p, "\"Alt\":null,");
     }
-    
+
     // Altitude Source. True if altitude source is GNSS, false if pressure altitude.
-    if (mm->bFlags & MODES_ACFLAGS_ALTITUDE_HAE_VALID) { 
+    if (mm->bFlags & MODES_ACFLAGS_ALTITUDE_HAE_VALID) {
         p += sprintf(p, "\"AltIsGNSS\":true,");
 	} else {
         p += sprintf(p, "\"AltIsGNSS\":false,");
@@ -824,20 +824,20 @@ static void modesSendStratuxOutput(struct modesMessage *mm, struct aircraft *a) 
         p += sprintf(p, "\"GnssDiffFromBaroAlt\":%d,",a->hae_delta);
     } else {
         p += sprintf(p, "\"GnssDiffFromBaroAlt\":null,");
-    }    
-    
+    }
+
  	//Vertical velocity
 	if (mm->bFlags & MODES_ACFLAGS_VERTRATE_VALID) {
 		p += sprintf(p, "\"Vvel\":%d,", mm->vert_rate);
 	} else {
 		p += sprintf(p,  "\"Vvel\":null,");
-	} 
+	}
 
 	// Ground speed and track
     if (mm->bFlags & MODES_ACFLAGS_SPEED_VALID) {
         p += sprintf(p, "\"Speed_valid\":true,\"Speed\":%d,", mm->velocity);
     } else {
-        p += sprintf(p, "\"Speed_valid\":false,\"Speed\":null,"); 
+        p += sprintf(p, "\"Speed_valid\":false,\"Speed\":null,");
     }
 
     if (mm->bFlags & MODES_ACFLAGS_HEADING_VALID) {
@@ -848,14 +848,14 @@ static void modesSendStratuxOutput(struct modesMessage *mm, struct aircraft *a) 
 
     // Find current system time
     clock_gettime(CLOCK_REALTIME, &now);
-    gmtime_r(&now.tv_sec, &stTime_now);  // we expect UTC 
+    gmtime_r(&now.tv_sec, &stTime_now);  // we expect UTC
 
     // Find message reception time
     gmtime_r(&mm->sysTimestampMsg.tv_sec, &stTime_receive); // we expect UTC
 
     //Time message received (based on system clock). Format is 2016-02-20T06:35:43.155Z
 	p += sprintf(p, "\"Timestamp\":\"%04d-%02d-%02dT%02d:%02d:%02d.%03dZ\"", (stTime_receive.tm_year+1900),(stTime_receive.tm_mon+1), stTime_receive.tm_mday, stTime_receive.tm_hour, stTime_receive.tm_min, stTime_receive.tm_sec, (unsigned) (mm->sysTimestampMsg.tv_nsec / 1000000U));
-    
+
     p += sprintf(p, "}\r\n");
 
     completeWrite(&Modes.stratux_out, p);
@@ -926,7 +926,7 @@ static int decodeBinMessage(struct client *c, char *p) {
     memset(&mm, 0, sizeof(mm));
 
     ch = *p++; /// Get the message type
-    if (0x1A == ch) {p++;} 
+    if (0x1A == ch) {p++;}
 
     if       ((ch == '1') && (Modes.mode_ac)) { // skip ModeA/C unless user enables --modes-ac
         msgLen = MODEAC_MSG_BYTES;
@@ -1002,13 +1002,13 @@ static int hexDigitVal(int c) {
 //
 // This function decodes a string representing message in raw hex format
 // like: *8D4B969699155600E87406F5B69F; The string is null-terminated.
-// 
+//
 // The message is passed to the higher level layers, so it feeds
 // the selected screen output, the network output and so forth.
-// 
+//
 // If the message looks invalid it is silently discarded.
 //
-// The function always returns 0 (success) to the caller as there is no 
+// The function always returns 0 (success) to the caller as there is no
 // case where we want broken messages here to close the client connection.
 //
 static int decodeHexMessage(struct client *c, char *hex) {
@@ -1058,13 +1058,13 @@ static int decodeHexMessage(struct client *c, char *hex) {
             break;}
     }
 
-    if ( (l != (MODEAC_MSG_BYTES      * 2)) 
-      && (l != (MODES_SHORT_MSG_BYTES * 2)) 
+    if ( (l != (MODEAC_MSG_BYTES      * 2))
+      && (l != (MODES_SHORT_MSG_BYTES * 2))
       && (l != (MODES_LONG_MSG_BYTES  * 2)) )
         {return (0);} // Too short or long message... broken
 
-    if ( (0 == Modes.mode_ac) 
-      && (l == (MODEAC_MSG_BYTES * 2)) ) 
+    if ( (0 == Modes.mode_ac)
+      && (l == (MODEAC_MSG_BYTES * 2)) )
         {return (0);} // Right length for ModeA/C, but not enabled
 
     for (j = 0; j < l; j += 2) {
@@ -1178,11 +1178,11 @@ char *generateAircraftJson(const char *url_path, int *len) {
             continue;
         }
 
-        if (first)            
+        if (first)
             first = 0;
         else
             *p++ = ',';
-            
+
         p += snprintf(p, end-p, "\n    {\"hex\":\"%s%06x\"", (a->addr & MODES_NON_ICAO_ADDRESS) ? "~" : "", a->addr & 0xFFFFFF);
         if (a->bFlags & MODES_ACFLAGS_SQUAWK_VALID)
             p += snprintf(p, end-p, ",\"squawk\":\"%04x\"", a->modeA);
@@ -1215,7 +1215,7 @@ char *generateAircraftJson(const char *url_path, int *len) {
                       a->messages, (now - a->seen)/1000.0,
                       10 * log10((a->signalLevel[0] + a->signalLevel[1] + a->signalLevel[2] + a->signalLevel[3] +
                                   a->signalLevel[4] + a->signalLevel[5] + a->signalLevel[6] + a->signalLevel[7] + 1e-5) / 8));
-        
+
         // If we're getting near the end of the buffer, expand it.
         if ((end - p) < 512) {
             int used = p - buf;
@@ -1347,7 +1347,7 @@ static char * appendStatsJson(char *p,
 
     return p;
 }
-    
+
 char *generateStatsJson(const char *url_path, int *len) {
     struct stats add;
     char *buf = (char *) malloc(4096), *p = buf, *end = buf + 4096;
@@ -1369,7 +1369,7 @@ char *generateStatsJson(const char *url_path, int *len) {
 
     add_stats(&Modes.stats_alltime, &Modes.stats_current, &add);
     p = appendStatsJson(p, end, &add, "total");
-    p += snprintf(p, end-p, "\n}\n");    
+    p += snprintf(p, end-p, "\n}\n");
 
     assert(p <= end);
 
@@ -1455,7 +1455,7 @@ void writeJsonToFile(const char *file, char * (*generator) (const char *,int*))
     fd = mkstemp(tmppath);
     if (fd < 0)
         return;
-    
+
     mask = umask(0);
     umask(mask);
     fchmod(fd, 0644 & ~mask);
@@ -1554,7 +1554,7 @@ static int handleHTTPRequest(struct client *c, char *p) {
         printf("\nHTTP keep alive: %d\n", keepalive);
         printf("HTTP requested URL: %s\n\n", url);
     }
-    
+
     // Ditch any trailing query part (AJAX might add one to avoid caching)
     p = strchr(url, '?');
     if (p) *p = 0;
@@ -1577,7 +1577,7 @@ static int handleHTTPRequest(struct client *c, char *p) {
             break;
         }
     }
-            
+
     if (!content) {
         struct stat sbuf;
         int fd = -1;
@@ -1617,7 +1617,7 @@ static int handleHTTPRequest(struct client *c, char *p) {
             statuscode = 404;
             statusmsg = "Not Found";
         }
-        
+
         if (fd != -1) {
             close(fd);
         }
@@ -1625,7 +1625,7 @@ static int handleHTTPRequest(struct client *c, char *p) {
         // Get file extension and content type
         content_type = MODES_CONTENT_TYPE_HTML; // Default content type
         ext = strrchr(getFile, '.');
-        
+
         if (ext) {
             if (!strcmp(ext, ".json")) {
                 content_type = MODES_CONTENT_TYPE_JSON;
@@ -1665,10 +1665,10 @@ static int handleHTTPRequest(struct client *c, char *p) {
 
     // Send header and content.
 #ifndef _WIN32
-    if ( (write(c->fd, hdr, hdrlen) != hdrlen) 
+    if ( (write(c->fd, hdr, hdrlen) != hdrlen)
       || (write(c->fd, content, clen) != clen) ) {
 #else
-    if ( (send(c->fd, hdr, hdrlen, 0) != hdrlen) 
+    if ( (send(c->fd, hdr, hdrlen, 0) != hdrlen)
       || (send(c->fd, content, clen, 0) != clen) ) {
 #endif
         free(content);
@@ -1885,7 +1885,7 @@ static void writeFATSV()
             altValid = (altAge <= 30000);
             used_tisb |= (a->tisbFlags & MODES_ACFLAGS_ALTITUDE_VALID);
         }
-        
+
         if (flags & MODES_ACFLAGS_AOG_VALID) {
             groundValid = 1;
 
@@ -2013,7 +2013,7 @@ static void writeFATSV()
         if (p <= end)
             completeWrite(&Modes.fatsv_out, p);
         else
-            fprintf(stderr, "fatsv: output too large (max %d, overran by %d)\n", TSV_MAX_PACKET_SIZE, (int) (p - end));
+            FPRINTF(stderr, "fatsv: output too large (max %d, overran by %d)\n", TSV_MAX_PACKET_SIZE, (int) (p - end));
 #       undef bufsize
 
         a->fatsv_last_emitted = now;

--- a/stratux_exports.h
+++ b/stratux_exports.h
@@ -1,0 +1,5 @@
+
+void log1090(char *s);
+void stratuxLog(char *fmt, ...);
+int start1090(int indexID, int ppm);
+void stop1090(void);

--- a/track.c
+++ b/track.c
@@ -4,20 +4,20 @@
 //
 // Copyright (c) 2014,2015 Oliver Jowett <oliver@mutability.co.uk>
 //
-// This file is free software: you may copy, redistribute and/or modify it  
+// This file is free software: you may copy, redistribute and/or modify it
 // under the terms of the GNU General Public License as published by the
-// Free Software Foundation, either version 2 of the License, or (at your  
-// option) any later version.  
+// Free Software Foundation, either version 2 of the License, or (at your
+// option) any later version.
 //
-// This file is distributed in the hope that it will be useful, but  
-// WITHOUT ANY WARRANTY; without even the implied warranty of  
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU  
+// This file is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 // General Public License for more details.
 //
-// You should have received a copy of the GNU General Public License  
+// You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-// This file incorporates work covered by the following copyright and  
+// This file incorporates work covered by the following copyright and
 // permission notice:
 //
 //   Copyright (C) 2012 by Salvatore Sanfilippo <antirez@gmail.com>
@@ -69,8 +69,8 @@ struct aircraft *trackCreateAircraft(struct modesMessage *mm) {
         a->signalLevel[i] = 1e-5;
     a->signalNext = 0;
 
-    // mm->msgtype 32 is used to represent Mode A/C. These values can never change, so 
-    // set them once here during initialisation, and don't bother to set them every 
+    // mm->msgtype 32 is used to represent Mode A/C. These values can never change, so
+    // set them once here during initialisation, and don't bother to set them every
     // time this ModeA/C is received again in the future
     if (mm->msgtype == 32) {
         a->modeACflags = MODEAC_MSG_FLAG;
@@ -188,7 +188,7 @@ static int speed_check(struct aircraft *a, struct modesMessage *mm, double lat, 
     inrange = (distance <= range);
 #ifdef DEBUG_CPR_CHECKS
     if (!inrange) {
-        fprintf(stderr, "Speed check failed: %06x: %.3f,%.3f -> %.3f,%.3f in %.1f seconds, max speed %d kt, range %.1fkm, actual %.1fkm\n",
+        FPRINTF(stderr, "Speed check failed: %06x: %.3f,%.3f -> %.3f,%.3f in %.1f seconds, max speed %d kt, range %.1fkm, actual %.1fkm\n",
                 a->addr, a->lat, a->lon, lat, lon, elapsed/1000.0, speed, range/1000.0, distance/1000.0);
     }
 #endif
@@ -238,8 +238,8 @@ static int doGlobalCPR(struct aircraft *a, struct modesMessage *mm, uint64_t now
     if (result < 0) {
 #ifdef DEBUG_CPR_CHECKS
         if (mm->bFlags & MODES_ACFLAGS_FROM_MLAT) {
-            fprintf(stderr, "CPR: decode failure from MLAT (%06X) (%d).\n", a->addr, result);
-            fprintf(stderr, "  even: %d %d   odd: %d %d  fflag: %s\n",
+            FPRINTF(stderr, "CPR: decode failure from MLAT (%06X) (%d).\n", a->addr, result);
+            FPRINTF(stderr, "  even: %d %d   odd: %d %d  fflag: %s\n",
                     a->even_cprlat, a->even_cprlon,
                     a->odd_cprlat, a->odd_cprlon,
                     fflag ? "odd" : "even");
@@ -253,7 +253,7 @@ static int doGlobalCPR(struct aircraft *a, struct modesMessage *mm, uint64_t now
         double range = greatcircle(Modes.fUserLat, Modes.fUserLon, *lat, *lon);
         if (range > Modes.maxRange) {
 #ifdef DEBUG_CPR_CHECKS
-            fprintf(stderr, "Global range check failed: %06x: %.3f,%.3f, max range %.1fkm, actual %.1fkm\n",
+            FPRINTF(stderr, "Global range check failed: %06x: %.3f,%.3f, max range %.1fkm, actual %.1fkm\n",
                     a->addr, *lat, *lon, Modes.maxRange/1000.0, range/1000.0);
 #endif
 
@@ -296,7 +296,7 @@ static int doLocalCPR(struct aircraft *a, struct modesMessage *mm, uint64_t now,
     } else if (!surface && (Modes.bUserFlags & MODES_USER_LATLON_VALID)) {
         reflat = Modes.fUserLat;
         reflon = Modes.fUserLon;
-        
+
         // The cell size is at least 360NM, giving a nominal
         // max range of 180NM (half a cell).
         //
@@ -387,7 +387,7 @@ static void updatePosition(struct aircraft *a, struct modesMessage *mm, uint64_t
         if (location_result == -2) {
 #ifdef DEBUG_CPR_CHECKS
             if (mm->bFlags & MODES_ACFLAGS_FROM_MLAT) {
-                fprintf(stderr, "CPR failure from MLAT (%06X).\n", a->addr);
+                FPRINTF(stderr, "CPR failure from MLAT (%06X).\n", a->addr);
             }
 #endif
             // Global CPR failed because the position produced implausible results.
@@ -411,7 +411,7 @@ static void updatePosition(struct aircraft *a, struct modesMessage *mm, uint64_t
         } else if (location_result == -1) {
 #ifdef DEBUG_CPR_CHECKS
             if (mm->bFlags & MODES_ACFLAGS_FROM_MLAT) {
-                fprintf(stderr, "CPR skipped from MLAT (%06X).\n", a->addr);
+                FPRINTF(stderr, "CPR skipped from MLAT (%06X).\n", a->addr);
             }
 #endif
             // No local reference for surface position available, or the two messages crossed a zone.
@@ -636,18 +636,18 @@ struct aircraft *trackUpdateFromMessage(struct modesMessage *mm)
 // A Mode S equipped aircraft may also respond to Mode A and Mode C SSR interrogations.
 // We can't tell if this is a Mode A or C, so scan through the entire aircraft list
 // looking for matches on Mode A (squawk) and Mode C (altitude). Flag in the Mode S
-// records that we have had a potential Mode A or Mode C response from this aircraft. 
+// records that we have had a potential Mode A or Mode C response from this aircraft.
 //
-// If an aircraft responds to Mode A then it's highly likely to be responding to mode C 
+// If an aircraft responds to Mode A then it's highly likely to be responding to mode C
 // too, and vice verca. Therefore, once the mode S record is tagged with both a Mode A
 // and a Mode C flag, we can be fairly confident that this Mode A/C frame relates to that
 // Mode S aircraft.
 //
-// Mode C's are more likely to clash than Mode A's; There could be several aircraft 
-// cruising at FL370, but it's less likely (though not impossible) that there are two 
+// Mode C's are more likely to clash than Mode A's; There could be several aircraft
+// cruising at FL370, but it's less likely (though not impossible) that there are two
 // aircraft on the same squawk. Therefore, give precidence to Mode A record matches
 //
-// Note : It's theoretically possible for an aircraft to have the same value for Mode A 
+// Note : It's theoretically possible for an aircraft to have the same value for Mode A
 // and Mode C. Therefore we have to check BOTH A AND C for EVERY S.
 //
 static void trackUpdateAircraftModeA(struct aircraft *a)
@@ -655,7 +655,7 @@ static void trackUpdateAircraftModeA(struct aircraft *a)
     struct aircraft *b = Modes.aircrafts;
 
     while(b) {
-        if ((b->modeACflags & MODEAC_MSG_FLAG) == 0) {  // skip any fudged ICAO records 
+        if ((b->modeACflags & MODEAC_MSG_FLAG) == 0) {  // skip any fudged ICAO records
 
             // If both (a) and (b) have valid squawks...
             if ((a->bFlags & b->bFlags) & MODES_ACFLAGS_SQUAWK_VALID) {
@@ -667,7 +667,7 @@ static void trackUpdateAircraftModeA(struct aircraft *a)
                     if ( (b->modeAcount > 0) &&
                        ( (b->modeCcount > 1)
                       || (a->modeACflags & MODEAC_MSG_MODEA_ONLY)) ) // Allow Mode-A only matches if this Mode-A is invalid Mode-C
-                        {a->modeACflags |= MODEAC_MSG_MODES_HIT;}    // flag this ModeA/C probably belongs to a known Mode S                    
+                        {a->modeACflags |= MODEAC_MSG_MODES_HIT;}    // flag this ModeA/C probably belongs to a known Mode S
                 }
             }
 
@@ -682,7 +682,7 @@ static void trackUpdateAircraftModeA(struct aircraft *a)
                     a->modeACflags |= MODEAC_MSG_MODEC_HIT;
                     if ( (b->modeAcount > 0) &&
                          (b->modeCcount > 1) )
-                        {a->modeACflags |= (MODEAC_MSG_MODES_HIT | MODEAC_MSG_MODEC_OLD);} // flag this ModeA/C probably belongs to a known Mode S                    
+                        {a->modeACflags |= (MODEAC_MSG_MODES_HIT | MODEAC_MSG_MODEC_OLD);} // flag this ModeA/C probably belongs to a known Mode S
                 }
             }
         }
@@ -719,7 +719,7 @@ static void trackRemoveStaleAircraft(uint64_t now)
 {
     struct aircraft *a = Modes.aircrafts;
     struct aircraft *prev = NULL;
-    
+
     while(a) {
         if ((now - a->seen) > TRACK_AIRCRAFT_TTL ||
             (a->messages == 1 && (now - a->seen) > TRACK_AIRCRAFT_ONEHIT_TTL)) {

--- a/view1090.c
+++ b/view1090.c
@@ -41,20 +41,20 @@ void sigintHandler(int dummy) {
 //
 #ifndef _WIN32
 // Get the number of rows after the terminal changes size.
-int getTermRows() { 
-    struct winsize w; 
-    ioctl(STDOUT_FILENO, TIOCGWINSZ, &w); 
-    return (w.ws_row); 
-} 
+int getTermRows() {
+    struct winsize w;
+    ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
+    return (w.ws_row);
+}
 
 // Handle resizing terminal
 void sigWinchCallback() {
     signal(SIGWINCH, SIG_IGN);
     Modes.interactive_rows = getTermRows();
     interactiveShowData();
-    signal(SIGWINCH, sigWinchCallback); 
+    signal(SIGWINCH, sigWinchCallback);
 }
-#else 
+#else
 int getTermRows() { return MODES_INTERACTIVE_ROWS;}
 #endif
 //
@@ -79,29 +79,29 @@ void view1090Init(void) {
     pthread_cond_init(&Modes.data_cond,NULL);
 
 #ifdef _WIN32
-    if ( (!Modes.wsaData.wVersion) 
+    if ( (!Modes.wsaData.wVersion)
       && (!Modes.wsaData.wHighVersion) ) {
       // Try to start the windows socket support
-      if (WSAStartup(MAKEWORD(2,1),&Modes.wsaData) != 0) 
+      if (WSAStartup(MAKEWORD(2,1),&Modes.wsaData) != 0)
         {
-        fprintf(stderr, "WSAStartup returned Error\n");
+        FPRINTF(stderr, "WSAStartup returned Error\n");
         }
       }
 #endif
 
     // Validate the users Lat/Lon home location inputs
     if ( (Modes.fUserLat >   90.0)  // Latitude must be -90 to +90
-      || (Modes.fUserLat <  -90.0)  // and 
+      || (Modes.fUserLat <  -90.0)  // and
       || (Modes.fUserLon >  360.0)  // Longitude must be -180 to +360
       || (Modes.fUserLon < -180.0) ) {
         Modes.fUserLat = Modes.fUserLon = 0.0;
     } else if (Modes.fUserLon > 180.0) { // If Longitude is +180 to +360, make it -180 to 0
         Modes.fUserLon -= 360.0;
     }
-    // If both Lat and Lon are 0.0 then the users location is either invalid/not-set, or (s)he's in the 
-    // Atlantic ocean off the west coast of Africa. This is unlikely to be correct. 
-    // Set the user LatLon valid flag only if either Lat or Lon are non zero. Note the Greenwich meridian 
-    // is at 0.0 Lon,so we must check for either fLat or fLon being non zero not both. 
+    // If both Lat and Lon are 0.0 then the users location is either invalid/not-set, or (s)he's in the
+    // Atlantic ocean off the west coast of Africa. This is unlikely to be correct.
+    // Set the user LatLon valid flag only if either Lat or Lon are non zero. Note the Greenwich meridian
+    // is at 0.0 Lon,so we must check for either fLat or fLon being non zero not both.
     // Testing the flag at runtime will be much quicker than ((fLon != 0.0) || (fLat != 0.0))
     Modes.bUserFlags &= ~MODES_USER_LATLON_VALID;
     if ((Modes.fUserLat != 0.0) || (Modes.fUserLon != 0.0)) {
@@ -196,7 +196,7 @@ int main(int argc, char **argv) {
             showHelp();
             exit(0);
         } else {
-            fprintf(stderr, "Unknown or not enough arguments for option '%s'.\n\n", argv[j]);
+            FPRINTF(stderr, "Unknown or not enough arguments for option '%s'.\n\n", argv[j]);
             showHelp();
             exit(1);
         }
@@ -221,7 +221,7 @@ int main(int argc, char **argv) {
     s = makeBeastInputService();
     c = serviceConnect(s, bo_connect_ipaddr, bo_connect_port);
     if (!c) {
-        fprintf(stderr, "Failed to connect to %s:%d: %s\n", bo_connect_ipaddr, bo_connect_port, Modes.aneterr);
+        FPRINTF(stderr, "Failed to connect to %s:%d: %s\n", bo_connect_ipaddr, bo_connect_port, Modes.aneterr);
         exit(1);
     }
 


### PR DESCRIPTION
The go and dump1090 code required only small changes and the sdr handling is simpler and a bit faster now.  The way gen_gdl90 interfaces to dump1090 for info doesn't change in any way nor does the dump1090 structure/functionality-onlysdr.go and dum1090.c have been modified.  What changes is the way we command/drive the dump1090 process. Previously we spawned the binary and passed it parameters whereas with the a shared library we call in to it and let it run.  When built as a binary, main does some setup and drops in to a while loop until exit, with the library we spawn a renamed, and simplified, main in a thread and let it run.

We add three new functions to dump1090.c  (start1090, stop1090, stratuxLog), rename main to start_main, and export the function log1090 from Go. In the sdr.go file when ES config is called we call C.start1090, passing it the dongle index to config and a ppm value, spawn start_main in a thread and return. When ES shutdown is called we call C.stop1090, which sets a flag telling start_main to exit, and once start_main exits stop1090 returns. For logging, when dump1090 is compiled as a lib there's a FPRINTF macro that calls stratuxLog which in turn calls log1090 so message strings get written to the stratux log.